### PR TITLE
fix: adjust global navigation

### DIFF
--- a/maps/templates/maps/global_nav.html
+++ b/maps/templates/maps/global_nav.html
@@ -15,7 +15,10 @@
             Platform Cooperativism Consortium</a>
         </li>
         <li class="global-nav__list-item">
-          <a class="global-nav__link" aria-current="true" rel="home" href="https://resources.platform.coop/">Resource
+            <a class="global-nav__link" aria-current="true" rel="home" href="/">Directory</a>
+        </li>
+        <li class="global-nav__list-item">
+          <a class="global-nav__link" rel="external" href="https://resources.platform.coop/">Resource
             Library</a>
         </li>
       </ul class="global-nav__list">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

- Adds global nav item for Directory with appropriate `rel` and `aria-current` attributes
- Adjusts global nav item for Resource Library's `rel` attribute and remove `aria-current` attribute

## Steps to test

Global nav should link to Directory and Resource Library, with `aria-current="true"` and `rel="home"` applied to the directory link.

## Additional information

Not applicable.

## Related issues

Not applicable.
