### PR TITLE
feat: add about page (resolves #52)

### DIFF
--- a/maps/static/maps/css/app.scss
+++ b/maps/static/maps/css/app.scss
@@ -3,11 +3,13 @@
 #map {
   top: 0;
   bottom: 0;
+  margin-top: $gutter;
   width: 100%;
   height: 580px;
   color: #203131;
   font-family: 'Noto Sans', sans-serif;
 }
+
 #map.organization {
   font-family: 'Noto Serif', serif;
 }

--- a/maps/templates/maps/about.html
+++ b/maps/templates/maps/about.html
@@ -1,0 +1,19 @@
+{% extends 'maps/base.html' %}
+{% load static %}
+{% load maps_extras %}
+{% block title %}{{ title |titlify }}{% endblock %}
+{% block content %}
+    <div class="page-header">
+        <p><a class="link--breadcrumb" href="/">Home</a></p>
+        <h1>About</h1>
+    </div>
+    <p>The Platform Co-op Directory is a place where you can search for and connect with cooperatives and other members of the cooperative community.
+    <h2>Who this is for</h2>
+    <p>The directory is for anyone and everyone who wants to learn more about the cooperative community, to connect with others in that community, and/or to share information with the cooperative community about themselves or their organisation.</p>
+    <h2>Who curates this</h2>
+    <p>Directory entries are created by the organizations and individuals who wish to share their information with others in the community. Initial entries have also been gathered through surveys and entries that existed in a previous incarnation of the directory.</p>
+    <h2>How this was built</h2>
+    <p>The Directory was built in partnership with the <a href="https://platform.coop/" rel="external">Platform Cooperative Consortium</a>, the <a href="https://idrc.ocadu.ca" rel="external">Inclusive Design Research Centre</a>, and a group of co-designers from the cooperative community with whom we have engaged throughout the design process and to whom we are very grateful.</p>
+    <h2><a href="https://platform.coop/" rel="external">Learn more about us</a></h2>
+
+{% endblock %}

--- a/maps/templates/maps/base.html
+++ b/maps/templates/maps/base.html
@@ -14,7 +14,8 @@
   <link href="{% static 'maps/dist/css/app.css' %}" rel="stylesheet">
   <link rel="shortcut icon" href="{% static 'maps/dist/images/favicon.png' %}" type="image/x-icon">
 </head>
-<body class="home page">
+{% url 'index' as home_url %}
+<body class="page{% if request.get_full_path == home_url %} home{% endif %}">
 {% include 'maps/global_nav.html' %}
 {% include 'maps/header.html' %}
   <div class="wrap container" role="document">

--- a/maps/templates/maps/base.html
+++ b/maps/templates/maps/base.html
@@ -10,7 +10,6 @@
   <script src="https://api.mapbox.com/mapbox-gl-js/v1.7.0/mapbox-gl.js"></script>
   <link href="https://api.mapbox.com/mapbox-gl-js/v1.7.0/mapbox-gl.css" rel="stylesheet"/>
   <script src="https://d3js.org/d3.v5.min.js"></script>
-  {# <script src="{% static 'maps/scripts/pinecone.umd.js' %}"></script> #}
   <link href="{% static 'maps/dist/css/app.css' %}" rel="stylesheet">
   <link rel="shortcut icon" href="{% static 'maps/dist/images/favicon.png' %}" type="image/x-icon">
 </head>

--- a/maps/templates/maps/header.html
+++ b/maps/templates/maps/header.html
@@ -89,7 +89,7 @@
             {% endif %}
 
             <li class="menu-item menu-item-type-post_type menu-item-object-page"><a
-                href="#" class="menu__item">About</a></li>
+                href="/about/" class="menu__item">About</a></li>
 
             {% if user.is_authenticated %}
             <li class="menu__submenu-wrapper">

--- a/maps/templates/maps/index.html
+++ b/maps/templates/maps/index.html
@@ -3,9 +3,10 @@
 {% load maps_extras %}
 {% block title %}{{ 'Welcome'|titlify }}{% endblock %}
 {% block content %}
+        <div class="banner-pattern"></div>
         <div class="page-header">
           <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
-          <p class="subhead">Subhead.</p>
+          <p class="subhead">The Platform Co-op Directory is a place where you can search for and connect with co-operatives and other members of the co-operative community.</p>
         </div>
 {% include 'maps/search.html' %}
         <div id="map"></div>

--- a/maps/templates/maps/index.html
+++ b/maps/templates/maps/index.html
@@ -1,7 +1,7 @@
 {% extends 'maps/base.html' %}
 {% load static %}
 {% load maps_extras %}
-{% block title %}{{ 'Welcome'|titlify }}{% endblock %}
+{% block title %}{{ 'Welcome' | titlify }}{% endblock %}
 {% block content %}
         <div class="banner-pattern"></div>
         <div class="page-header">

--- a/maps/templates/maps/individual_detail.html
+++ b/maps/templates/maps/individual_detail.html
@@ -4,9 +4,7 @@
 {% block title %}{{ user.last_name|add:', '|add:user.first_name|titlify }}{% endblock %}
 {% block content %}
     <div class="page-header">
-        <p>
-            <div class="spacer"></div><a class="link--inverse" href="{% url 'index' %}">Home</a>
-        </p>
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
     {% include 'maps/search.html' %}

--- a/maps/templates/maps/individual_detail.html
+++ b/maps/templates/maps/individual_detail.html
@@ -1,10 +1,11 @@
 {% extends 'maps/base.html' %}
 {% load static %}
+{% load i18n %}
 {% load maps_extras %}
 {% block title %}{{ user.last_name|add:', '|add:user.first_name|titlify }}{% endblock %}
 {% block content %}
     <div class="page-header">
-        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
     {% include 'maps/search.html' %}

--- a/maps/templates/maps/organization_detail.html
+++ b/maps/templates/maps/organization_detail.html
@@ -4,9 +4,7 @@
 {% block title %}{{ organization.name|titlify }}{% endblock %}
 {% block content %}
     <div class="page-header">
-        <p>
-            <div class="spacer"></div><a class="link--inverse" href="{% url 'index' %}">Home</a>
-        </p>
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
     {% include 'maps/search.html' %}

--- a/maps/templates/maps/organization_detail.html
+++ b/maps/templates/maps/organization_detail.html
@@ -1,10 +1,11 @@
 {% extends 'maps/base.html' %}
 {% load static %}
+{% load i18n %}
 {% load maps_extras %}
 {% block title %}{{ organization.name|titlify }}{% endblock %}
 {% block content %}
     <div class="page-header">
-        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
     {% include 'maps/search.html' %}

--- a/maps/templates/maps/privacy_policy.html
+++ b/maps/templates/maps/privacy_policy.html
@@ -1,10 +1,11 @@
 {% extends 'maps/base.html' %}
 {% load static %}
+{% load i18n %}
 {% load maps_extras %}
 {% block title %}{{ title |titlify }}{% endblock %}
 {% block content %}
         <div class="page-header">
-        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
           <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
         </div>
 {% include 'maps/search.html' %}

--- a/maps/templates/maps/privacy_policy.html
+++ b/maps/templates/maps/privacy_policy.html
@@ -4,8 +4,8 @@
 {% block title %}{{ title |titlify }}{% endblock %}
 {% block content %}
         <div class="page-header">
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
           <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
-          <p class="subhead">Subhead.</p>
         </div>
 {% include 'maps/search.html' %}
         <p>

--- a/maps/templates/maps/profile.html
+++ b/maps/templates/maps/profile.html
@@ -2,8 +2,8 @@
 {% load static %}
 {% block content %}
     <div class="page-header">
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
-        <p class="subhead">Subhead.</p>
     </div>
     {% include 'maps/search.html' %}
     <div id="foo">Hello {{ user.first_name }}</div>

--- a/maps/templates/maps/profile.html
+++ b/maps/templates/maps/profile.html
@@ -1,8 +1,9 @@
 {% extends 'maps/base.html' %}
 {% load static %}
+{% load i18n %}
 {% block content %}
     <div class="page-header">
-        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
     {% include 'maps/search.html' %}

--- a/maps/templates/maps/search.html
+++ b/maps/templates/maps/search.html
@@ -3,7 +3,7 @@
 <form role="search" method="get" class="search-form search-form--inverse" action="/">
     <label>
         <span class="screen-reader-text">search</span>
-        <input id="s" name="s" placeholder="Search resource name, publisher, or topic…" type="search">
+        <input id="s" name="s" placeholder="Search by co-op or individual name, details, or tags…" type="search">
     </label>
     <button type="submit" class="button button--search" disabled><span class="screen-reader-text">submit search</span>          <svg
               class="icon icon--search"

--- a/maps/templates/maps/terms_of_service.html
+++ b/maps/templates/maps/terms_of_service.html
@@ -4,8 +4,8 @@
 {% block title %}{{ title |titlify }}{% endblock %}
 {% block content %}
     <div class="page-header">
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
-        <p class="subhead">Subhead.</p>
     </div>
     {% include 'maps/search.html' %}
     <h2>Terms of Use ("Terms")</h2>

--- a/maps/templates/maps/terms_of_service.html
+++ b/maps/templates/maps/terms_of_service.html
@@ -1,10 +1,11 @@
 {% extends 'maps/base.html' %}
 {% load static %}
+{% load i18n %}
 {% load maps_extras %}
 {% block title %}{{ title |titlify }}{% endblock %}
 {% block content %}
     <div class="page-header">
-        <p><a class="link--breadcrumb" href="{% url 'index' %}">Home</a></p>
+        <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
     {% include 'maps/search.html' %}

--- a/maps/templatetags/maps_extras.py
+++ b/maps/templatetags/maps_extras.py
@@ -5,5 +5,5 @@ register = template.Library()
 @register.filter(name='titlify')
 def titlify(value):
     """Prepends value and emdash to base title"""
-    title_base = 'Platform Cooperativism Consortium'
+    title_base = 'Platform Co-op Directory'
     return value + ' – ' + title_base

--- a/maps/urls.py
+++ b/maps/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from django.conf.urls import url
 from . import views
 from .views import INDIVIDUAL_FORMS, IndividualProfileWizard, OrganizationAutocomplete,\
-    PrivacyPolicyView, TermsOfServiceView
+    PrivacyPolicyView, TermsOfServiceView, AboutPageView
 from accounts.models import UserSocialNetwork
 
 urlpatterns = [
@@ -12,6 +12,7 @@ urlpatterns = [
     url(r'^organization-autocomplete/$', OrganizationAutocomplete.as_view(create_field='name'), name='organization-autocomplete'),
     path('organizations/<int:organization_id>', views.organization_detail, name='organization_detail'),
     path('individuals/<int:user_id>', views.individual_detail, name='individual-detail'),
+    path('about/', AboutPageView.as_view(), {'title': 'About'}, name='about'),
     path('privacy-policy/', PrivacyPolicyView.as_view(), {'title': 'Privacy Policy'}, name='privacy_policy'),
     path('terms-of-service/', TermsOfServiceView.as_view(), {'title': 'Terms of Service'}, name='terms_of_service'),
 ]

--- a/maps/views.py
+++ b/maps/views.py
@@ -150,4 +150,6 @@ class PrivacyPolicyView(TemplateView):
 class TermsOfServiceView(TemplateView):
     template_name = "maps/terms_of_service.html"
 
+class AboutPageView(TemplateView):
+    template_name = "maps/about.html"
 


### PR DESCRIPTION

* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds about page. Removes boilerplate subheads, adds standard breadcrumb link throughout.

## Steps to test

1. Load demo site.
2. Follow navigation link to `/about/`.

**Expected behavior:** Page matches expectations.

## Additional information

Does not yet include impact summary (see #35).

## Related issues

Resolves #52.
