### PR TITLE
fix: clean up search implementation

### DIFF
--- a/maps/templates/maps/header.html
+++ b/maps/templates/maps/header.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% url 'index' as home_url %}
   <div class="banner-pattern"></div>
   <header role="banner">
     <div class="container">
@@ -10,6 +11,7 @@
         <span class="brand__title screen-reader-text">Platform Cooperativism Consortium</span></a>
 
       <div class="inner">
+      {% if request.get_full_path != home_url %}
         <button class="button button--borderless search-toggle" aria-expanded="false"><span
       class="screen-reader-text">Search </span>
           <svg
@@ -24,9 +26,9 @@
         <form role="search" method="get" class="search-form search-form--inverse" action="#">
           <label>
             <span class="screen-reader-text">search</span>
-            <input id="s" name="s" type="search" disabled/>
+            <input id="s" name="s" type="search" />
           </label>
-          <button type="submit" class="button button--search" disabled><span class="screen-reader-text">submit search</span>
+          <button type="submit" class="button button--search"><span class="screen-reader-text">submit search</span>
             <svg
                 class="icon icon--search"
                 aria-hidden="true"
@@ -37,6 +39,7 @@
             </svg>
           </button>
         </form>
+      {% endif %}
 
         <nav class="nav" aria-labelledby="menu-primary-label">
           <button class="button button--borderless menu-toggle" aria-expanded="false">

--- a/maps/templates/maps/individual_detail.html
+++ b/maps/templates/maps/individual_detail.html
@@ -8,7 +8,6 @@
         <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
-    {% include 'maps/search.html' %}
     {% if user.url %}
     <h1><a rel="external" href="{{ user.url }}">{{ user.last_name }}, {{ user.first_name }}</a></h1>
     {% else %}

--- a/maps/templates/maps/organization_detail.html
+++ b/maps/templates/maps/organization_detail.html
@@ -8,7 +8,6 @@
         <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
-    {% include 'maps/search.html' %}
     {% if organization.url %}
     <h1><a rel="external" href="{{ organization.url }}">{{ organization.name }}</a></h1>
     {% else %}

--- a/maps/templates/maps/privacy_policy.html
+++ b/maps/templates/maps/privacy_policy.html
@@ -8,7 +8,6 @@
         <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
           <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
         </div>
-{% include 'maps/search.html' %}
         <p>
             The Platform Cooperativism Consortium (PCC) is dedicated to respecting and protecting your privacy. At the
             PCC and ICDE, we are committed to making the processes and outcomes of our work transparent and accessible

--- a/maps/templates/maps/profile.html
+++ b/maps/templates/maps/profile.html
@@ -6,7 +6,6 @@
         <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
-    {% include 'maps/search.html' %}
     <div id="foo">Hello {{ user.first_name }}</div>
     <a href="{% url 'account_change_password' %}">Change password</a>
 {% endblock %}

--- a/maps/templates/maps/search.html
+++ b/maps/templates/maps/search.html
@@ -5,7 +5,7 @@
         <span class="screen-reader-text">search</span>
         <input id="s" name="s" placeholder="Search by co-op or individual name, details, or tags…" type="search">
     </label>
-    <button type="submit" class="button button--search" disabled><span class="screen-reader-text">submit search</span>          <svg
+    <button type="submit" class="button button--search"><span class="screen-reader-text">submit search</span>          <svg
               class="icon icon--search"
               viewBox="0 0 20 20"
               focusable="false"

--- a/maps/templates/maps/terms_of_service.html
+++ b/maps/templates/maps/terms_of_service.html
@@ -8,7 +8,6 @@
         <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
         <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
     </div>
-    {% include 'maps/search.html' %}
     <h2>Terms of Use ("Terms")</h2>
 
     <p>Last updated: 16 Mar 2020</p>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR brings search form implementation inline with Resource Library in the following ways:

- [x] Home page does not included search form in menu bar
- [x] All other pages include search form in menu bar but not in page body

## Steps to test

1. Visit home page.
2. Visit about page, individual, or organizational profile.

**Expected behavior:** Home page includes search in main body. Other pages include search in nav bar.

## Additional information

Not applicable.

## Related issues

Not applicable.
