### PR TITLE
feat: add continuous deployment workflow

### DIFF
--- a/.github/workflows/stack_demo.yml
+++ b/.github/workflows/stack_demo.yml
@@ -1,0 +1,41 @@
+name: demo.directory.platform.coop
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  PROJECT_ID: demo
+  PROJECT_SMOKETEST_URL: https://demo.directory.platform.coop
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy stack
+        uses: appleboy/ssh-action@master
+        with:
+          host:     ${{ secrets.SSH_HOSTNAME }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key:      ${{ secrets.SSH_PRIVATE_KEY }}
+          port:     ${{ secrets.SSH_PORT }}
+          envs:     PROJECT_ID
+          script: |
+            cd /srv/demo.directory.platform.coop                          && \
+            git checkout master                                           && \
+            git pull                                                      && \
+            source deploy.env                                             && \
+            /usr/local/bin/docker-compose -p $PROJECT_ID                     \
+                                          -f docker-compose.yml              \
+                                          up --force-recreate --build -d  && \
+            /usr/local/bin/docker-compose -p $PROJECT_ID                     \
+                                          -f docker-compose.yml              \
+                                          run app python3 manage.py migrate
+
+      - name: Wait
+        run: sleep 15
+
+      - name: Smoke test
+        run: curl --location --no-buffer --retry 120 --retry-delay 1 $PROJECT_SMOKETEST_URL

--- a/.github/workflows/stack_demo.yml
+++ b/.github/workflows/stack_demo.yml
@@ -32,7 +32,7 @@ jobs:
                                           up --force-recreate --build -d  && \
             /usr/local/bin/docker-compose -p $PROJECT_ID                     \
                                           -f docker-compose.yml              \
-                                          run app python3 manage.py migrate
+                                          run app python manage.py migrate
 
       - name: Wait
         run: sleep 15

--- a/.github/workflows/stack_dev.yml
+++ b/.github/workflows/stack_dev.yml
@@ -1,0 +1,41 @@
+name: dev.directory.platform.coop
+
+on:
+  push:
+    branches:
+      - dev
+
+env:
+  PROJECT_ID: dev
+  PROJECT_SMOKETEST_URL: https://dev.directory.platform.coop
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy stack
+        uses: appleboy/ssh-action@master
+        with:
+          host:     ${{ secrets.SSH_HOSTNAME }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key:      ${{ secrets.SSH_PRIVATE_KEY }}
+          port:     ${{ secrets.SSH_PORT }}
+          envs:     PROJECT_ID
+          script: |
+            cd /srv/dev.directory.platform.coop                           && \
+            git checkout dev                                              && \
+            git pull                                                      && \
+            source deploy.env                                             && \
+            /usr/local/bin/docker-compose -p $PROJECT_ID                     \
+                                          -f docker-compose.yml              \
+                                          up --force-recreate --build -d  && \
+            /usr/local/bin/docker-compose -p $PROJECT_ID                     \
+                                          -f docker-compose.yml              \
+                                          run app python3 manage.py migrate
+
+      - name: Wait
+        run: sleep 15
+
+      - name: Smoke test
+        run: curl --location --no-buffer --retry 120 --retry-delay 1 $PROJECT_SMOKETEST_URL

--- a/.github/workflows/stack_dev.yml
+++ b/.github/workflows/stack_dev.yml
@@ -32,7 +32,7 @@ jobs:
                                           up --force-recreate --build -d  && \
             /usr/local/bin/docker-compose -p $PROJECT_ID                     \
                                           -f docker-compose.yml              \
-                                          run app python3 manage.py migrate
+                                          run app python manage.py migrate
 
       - name: Wait
         run: sleep 15

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ FROM python:3
 
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update                                                      && \
-    apt-get install -y --no-install-recommends gdal-bin=2.4.0+dfsg-1+b1 && \
+RUN apt-get update                             && \
+    apt-get install -y --no-install-recommends    \
+        gdal-bin=2.4.0+dfsg-1+b1                  \
+        gunicorn=19.9.0-1                      && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -28,8 +30,10 @@ RUN pip install -r requirements.txt
 
 COPY . /app/
 
+RUN python manage.py collectstatic
+
 COPY --from=static_assets /app/maps /app/
 
 EXPOSE 8000
 
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "cmdi.wsgi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12 AS static_assets
+FROM node:12.18.0 AS static_assets
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ RUN npm run build
 
 
 
-FROM python:3
+FROM python:3.8.3
 
 ENV PYTHONUNBUFFERED 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install -r requirements.txt
 
 COPY . /app/
 
-RUN python manage.py collectstatic
+RUN python manage.py collectstatic --no-input --clear
 
 COPY --from=static_assets /app/maps /app/
 


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Add GitHub Actions workflows that will do continuous deployment of the {demo,dev} websites.

## Additional information

Before this works, the Secrets need to be added to the repository.