### PR TITLE
fix: remove django-autocomplete-light from cmdi/settings

### DIFF
--- a/cmdi/settings.py
+++ b/cmdi/settings.py
@@ -49,8 +49,6 @@ if ALLOWED_HOSTS != '':
 # Application definition
 
 INSTALLED_APPS = [
-    'dal',
-    'dal_select2',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This should fix the `collectstatic` issue introduced in #84.

## Steps to test

1. Check out branch.
2. Install python dependencies.
3. Run: `python manage.py collectstatic`

**Expected behavior:** Command succeeds.

## Additional information

I neglected to remove `dal` references from `cmdi/settings.py`.

## Related issues

Not applicable.
