### PR TITLE
fix: read email settings from environment variables

### DIFF
--- a/cmdi/settings.py
+++ b/cmdi/settings.py
@@ -176,8 +176,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-EMAIL_BACKEND = 'django_ses.SESBackend'
-DEFAULT_FROM_EMAIL = 'erictheise+pcc@gmail.com'
+EMAIL_BACKEND = os.getenv('DJANGO_EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend')
+EMAIL_HOST = os.getenv('DJANGO_EMAIL_HOST', 'localhost')
+DEFAULT_FROM_EMAIL = os.getenv('DJANGO_DEFAULT_FROM_EMAIL', 'noreply@localhost')
 
 LOGIN_REDIRECT_URL = '/'
 


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Read email settings from environment variables.

## Steps to test

Pass the following environment variables while starting the application to run it in the IDRC environment:

```
export DJANGO_EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend"
export DJANGO_EMAIL_HOST="svc-smtp-1.tor1.incd.ca"
export DJANGO_DEFAULT_FROM_EMAIL="noreply@demo.directory.platform.coop"
```