### PR TITLE
fix: pass env vars through docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - ${APP_PORT}:8000
     environment:
       - DATABASE_URL=postgis://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - DJANGO_EMAIL_BACKEND=${DJANGO_EMAIL_BACKEND}
+      - DJANGO_EMAIL_HOST=${DJANGO_EMAIL_HOST}
+      - DJANGO_DEFAULT_FROM_EMAIL=${DJANGO_DEFAULT_FROM_EMAIL}
     networks:
       - default
     restart: always


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

The variables are defined in the environment but need to be passed through docker-compose.

## Steps to test

1. docker compose up -f docker-compose.yml