### PR TITLE
feat: read debug option from environment variable

### DIFF
--- a/cmdi/settings.py
+++ b/cmdi/settings.py
@@ -39,7 +39,7 @@ SECRET_KEY = os.environ['SECRET_KEY']
 # SECURITY WARNING: don't run with debug turned on in production!
 # Environment variable values are strings, not Booleans, so we test the value of the string.
 # See https://stackoverflow.com/questions/30015462/django-ignoring-debug-value-when-i-use-os-environ-why
-DEBUG = os.environ['DEBUG'] == 'True'
+DEBUG = os.getenv('DEBUG', 'false').lower() == 'true'
 
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS')
 if ALLOWED_HOSTS != '':

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - DJANGO_EMAIL_BACKEND=${DJANGO_EMAIL_BACKEND}
       - DJANGO_EMAIL_HOST=${DJANGO_EMAIL_HOST}
       - DJANGO_DEFAULT_FROM_EMAIL=${DJANGO_DEFAULT_FROM_EMAIL}
+      - DEBUG=${DEBUG:-false}
     networks:
       - default
     restart: always


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Read DEBUG from environment variable

## Steps to test

1. export DEBUG="true" (or "false")
2. docker-compose -f docker-compose.yml up
3. config debugging is enabled (or disabled)

**Expected behavior:**

DEBUG is disabled by default.

## Additional information

dev.directory.platform.coop has been configured with DEBUG=true
demo.directory.platform.coop doesn't have a configuration for DEBUG (so it's disabled)