### PR TITLE
fix: prevent appearance of duplicate messages (resolves #99)

### DIFF
--- a/maps/templates/maps/account_settings.html
+++ b/maps/templates/maps/account_settings.html
@@ -8,6 +8,7 @@
         <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
         <h1>{% trans 'Account settings' %}</h1>
     </div>
+    {% include 'maps/partials/messages.html' %}
     <div class="stack">
         <ul class="link-list">
             <li class="link-list__item"><a href="{% url 'account_email' %}">{% trans 'Manage email addresses' %}</a></li>

--- a/maps/templates/maps/index.html
+++ b/maps/templates/maps/index.html
@@ -8,6 +8,7 @@
           <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
           <p class="subhead">The Platform Co-op Directory is a place where you can search for and connect with co-operatives and other members of the co-operative community.</p>
         </div>
+        {% include 'maps/partials/messages.html' %}
         {% include 'maps/search--home.html' %}
         <div id="main-map"></div>
         {% include 'maps/filters.html' %}

--- a/maps/templates/maps/individual_detail.html
+++ b/maps/templates/maps/individual_detail.html
@@ -32,7 +32,7 @@
         </p>
         {% endif %}
     </div>
-
+    {% include 'maps/partials/messages.html' %}
     <div class="tabs">
         <div role="tablist" aria-labelledby="tabs-label">
             <span class="screen-reader-text" id="tabs-label">{% trans 'tab group' %}</span>

--- a/maps/templates/maps/my_profiles.html
+++ b/maps/templates/maps/my_profiles.html
@@ -8,11 +8,7 @@
         <p><a class="link--breadcrumb" href="/">{% trans 'Home' %}</a></p>
         <h1>{% trans 'My profiles' %}</h1>
     </div>
-    {% if messages %}
-        {% for message in messages %}
-        {% include 'maps/partials/notification.html' %}
-        {% endfor %}
-    {% endif %}
+    {% include 'maps/partials/messages.html' %}
     <h2>{% trans 'Personal profile' %}</h2>
     {% if user.has_profile %}
     <ul class="cards">

--- a/maps/templates/maps/organization_detail.html
+++ b/maps/templates/maps/organization_detail.html
@@ -5,7 +5,6 @@
 {% block bodyclass %}profile profile--organization{% endblock %}
 {% block content %}
   <div class="page-header">
-      
       <p>
         {% if organization.type.icon %}{% icon organization.type.icon %}{% endif %}
         {{ organization.type }}
@@ -35,6 +34,7 @@
       </p>
       {% endif %}
   </div>
+  {% include 'maps/partials/messages.html' %}
   <div class="tabs">
   <div role="tablist" aria-labelledby="tabs-label">
     <span class="screen-reader-text" id="tabs-label">{% trans 'tab group' %}</span>

--- a/maps/templates/maps/partials/messages.html
+++ b/maps/templates/maps/partials/messages.html
@@ -1,0 +1,5 @@
+{% if messages %}
+    {% for message in messages %}
+    {% include 'maps/partials/notification.html' %}
+    {% endfor %}
+{% endif %}


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR ensures that messages are displayed on all pages to prevent the accumulation of unviewed messages (see #99).

## Steps to test

1. Log out.
2. Log in.
3. Navigate to My Profile.

**Expected behavior:** After bypassing lockdown, the home page should show "You have successfully logged out." (Styling needs work, but that is a separate issue.) Once you log in, the "Successfully logged in" message should be shown immediately.

## Additional information

Not applicable.

## Related issues

Resolves #99.
