### PR TITLE
feat: update organizations when email changes (resolves #117)

### DIFF
--- a/mdi/models.py
+++ b/mdi/models.py
@@ -378,6 +378,11 @@ class EntitiesEntities(models.Model):
     class Meta:
         verbose_name_plural = "Entity to Entity Relationships"
 
+# The relationship between a user and Organizations that they can administer is
+# maintained via the Organization.admin_email key. This receiver for
+# django-allauth's email_changed signal updates Organization.admin_email for
+# all related Organizations when a user changes their primary email.
+
 
 @receiver(email_changed)
 def email_changed_handler(request, user, from_email_address, to_email_address, **kwargs):

--- a/mdi/models.py
+++ b/mdi/models.py
@@ -1,15 +1,16 @@
 from django.contrib.postgres.fields import IntegerRangeField
 from django.contrib.auth import get_user_model
 from django.contrib.gis.db import models
+from django.dispatch import receiver
 from datetime import date
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from accounts.models import SocialNetwork
 from django_countries.fields import CountryField
-
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 from django.db.models import Manager as GeoManager
+from allauth.account.signals import email_changed
 
 
 class Type(models.Model):
@@ -376,3 +377,11 @@ class EntitiesEntities(models.Model):
 
     class Meta:
         verbose_name_plural = "Entity to Entity Relationships"
+
+
+@receiver(email_changed)
+def email_changed_handler(request, user, from_email_address, to_email_address, **kwargs):
+    orgs = Organization.objects.filter(admin_email=from_email_address)
+    for org in orgs:
+        org.admin_email = to_email_address.email
+        org.save()


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds a signal receiver which will ensure that an individual's account remains connected to their administered organizations if/when they change their primary email address.

## Steps to test

1. Ensure that you are logged in as a user with a few organizations which appear on your "My Profiles" page.
2. Navigate to "Account &rarr; Account settings".
3. Change your primary email address.

**Expected behavior:** The organizations remain visible on your "My Profiles" page, and their `Organization.admin_email` keys have been updated to the new primary email address.

## Additional information

- https://django-allauth.readthedocs.io/en/latest/signals.html#allauth-account

## Related issues

Resolves #117.
