### PR TITLE
feat: prevent users from adding duplicate orgs or tools

### DIFF
--- a/maps/templates/maps/partials/notification.html
+++ b/maps/templates/maps/partials/notification.html
@@ -5,6 +5,6 @@
     <span class="button__label screen-reader-text">{% trans 'Close notification' %}</span></button>
     <p class="notification__title">{% icon message.level_tag %}{{ message.level_tag | capfirst }}</p>
     <div class="notification__content">
-        {{ message }}
+        {{ message | safe }}
     </div>
 </div>

--- a/maps/templates/maps/profiles/errors.html
+++ b/maps/templates/maps/profiles/errors.html
@@ -7,8 +7,8 @@
         <span class="button__label screen-reader-text">{% trans 'Close notification' %}</span></button>
         <p class="notification__title">{% icon 'error' %}{{ field.label | safe }}</p>
         <div class="notification__content">
-            {% for error in field.errors %}
-            {{ error | escape }}
+            {% for message in field.errors %}
+            {{ message | safe }}
             {% endfor %}
         </div>
     </div>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Blocks users from adding duplicate organizations or tools.

## Steps to test

1. Initiate the process of adding a new organization or tool.
2. Enter the exact name of an existing organization or tool.
3. Attempt to proceed to the next step.

**Expected behavior:** User should be warned that an existing organization or tool with the same name exists, and shown a link to that organization or tool.

## Additional information

It would be nice to do a fuzzy match and show some existing similarly-named organizations or tools, but this is a good MVP.

## Related issues

Resolves #122.
