### PR TITLE
feat: add placeholders for social network profile input (resolves #100)

### DIFF
--- a/maps/forms.py
+++ b/maps/forms.py
@@ -186,6 +186,19 @@ class IndividualDetailedInfoForm(BaseModelForm):
 
 
 class IndividualSocialNetworkForm(BaseModelForm):
+    def __init__(self, *args, **kwargs):
+        if 'initial' in kwargs:
+            self.label = kwargs['initial']['name']
+            self.hint = kwargs['initial']['hint']
+        elif 'instance' in kwargs:
+            self.label = kwargs['instance'].socialnetwork.name
+            self.hint = kwargs['instance'].socialnetwork.hint
+        super(IndividualSocialNetworkForm, self).__init__(*args, **kwargs)
+        if hasattr(self, 'label'):
+            self.fields['identifier'].label = self.label
+        if hasattr(self, 'hint'):
+            self.fields['identifier'].widget = TextInput(attrs={'placeholder': self.hint})
+
     class Meta:
         model = UserSocialNetwork
         fields = [
@@ -193,7 +206,7 @@ class IndividualSocialNetworkForm(BaseModelForm):
             'identifier',
         ]
         widgets = {
-            'socialnetwork': HiddenInput(),
+            'socialnetwork': HiddenInput()
         }
 
 
@@ -588,6 +601,19 @@ class OrganizationScopeAndImpactForm(BaseModelForm):
 
 
 class OrganizationSocialNetworkForm(BaseModelForm):
+    def __init__(self, *args, **kwargs):
+        if 'initial' in kwargs:
+            self.label = kwargs['initial']['name']
+            self.hint = kwargs['initial']['hint']
+        elif 'instance' in kwargs:
+            self.label = kwargs['instance'].socialnetwork.name
+            self.hint = kwargs['instance'].socialnetwork.hint
+        super(OrganizationSocialNetworkForm, self).__init__(*args, **kwargs)
+        if hasattr(self, 'label'):
+            self.fields['identifier'].label = self.label
+        if hasattr(self, 'hint'):
+            self.fields['identifier'].widget = TextInput(attrs={'placeholder': self.hint})
+
     class Meta:
         model = OrganizationSocialNetwork
         fields = [

--- a/maps/templates/maps/profiles/individual/social_networks.html
+++ b/maps/templates/maps/profiles/individual/social_networks.html
@@ -21,7 +21,7 @@
         {% if wizard.form.forms %}
             {{ wizard.form.management_form }}
             {% for form in wizard.form.forms %}
-              <label for="{{ form.identifier.id_for_label }}">{{ form.initial.name }}</label>
+              {{ form.identifier.label_tag }}
               {{ form.identifier }}
               {{ form.socialnetwork }}
             {% endfor %}

--- a/maps/templates/maps/profiles/individual/update_overview.html
+++ b/maps/templates/maps/profiles/individual/update_overview.html
@@ -88,7 +88,7 @@
         {{ social_network_form.management_form }}
         {% for sn in social_network_form.forms %}
             {{ sn.id }}
-            <label for="{{ sn.identifier.id_for_label }}">{{ sn.initial.socialnetwork|social_network_id_to_label }}</label>
+            {{ sn.identifier.label_tag }}
             {{ sn.identifier }}
             {{ sn.socialnetwork }}
         {% endfor %}

--- a/maps/templates/maps/profiles/organization/social_networks.html
+++ b/maps/templates/maps/profiles/organization/social_networks.html
@@ -21,7 +21,7 @@
         {% if wizard.form.forms %}
             {{ wizard.form.management_form }}
             {% for form in wizard.form.forms %}
-              <label for="{{ form.identifier.id_for_label }}">{{ form.initial.name }}</label>
+              {{ form.identifier.label_tag }}
               {{ form.identifier }}
               {{ form.socialnetwork }}
             {% endfor %}

--- a/maps/templates/maps/profiles/organization/update_contact.html
+++ b/maps/templates/maps/profiles/organization/update_contact.html
@@ -62,7 +62,7 @@
         {{ social_network_form.management_form }}
         {% for sn in social_network_form.forms %}
             {{ sn.id }}
-            <label for="{{ sn.identifier.id_for_label }}">{{ sn.initial.socialnetwork|social_network_id_to_label }}</label>
+            {{ sn.identifier.label_tag }}
             {{ sn.identifier }}
             {{ sn.socialnetwork }}
         {% endfor %}

--- a/maps/templatetags/maps_extras.py
+++ b/maps/templatetags/maps_extras.py
@@ -11,16 +11,6 @@ def titlify(value):
     return value + ' – ' + title_base
 
 
-@register.filter(name='social_network_id_to_label')
-def social_network_id_to_label(id):
-    """Takes a Social Network instance ID and returns the label"""
-    sn = SocialNetwork.objects.get(id=id)
-    if sn:
-        return sn.name
-    else:
-        return None
-
-
 @register.inclusion_tag('maps/partials/icon.html')
 def icon(name, **kwargs):
     modifier = kwargs.get('modifier', name)


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds placeholders for social network fields on individual and organizational profiles, and derives labels from `SocialNetwork` model rather than requiring a custom filter or initial data.

## Steps to test

1. Add or edit an individual profile.
2. Add or edit an organizational profile.

**Expected behavior:** Social media fields include placeholder text which shows the required format of the input.

## Additional information

Not applicable.

## Related issues

Resolves #100.
