### PR TITLE
feat: allow cancellation of profile creation, block flow if profile exists (fix #27, fix #143)

### DIFF
--- a/maps/static/maps/js/app.js
+++ b/maps/static/maps/js/app.js
@@ -28,13 +28,17 @@ if (icons) {
   });
 }
 
-const dialogBtn = document.getElementById('invoke-dialog');
+const dialogBtn = document.getElementById('cancel-profile-creation');
 if (dialogBtn) {
+    let labels = JSON.parse(document.getElementById('labels').innerHTML);
     new Pinecone.Dialog(dialogBtn, {
-        title: 'Cancel',
-        question: 'Are you sure you want to exit the profile editor and delete all of your information?',
-        confirm: 'Yes, exit and delete all info',
-        dismiss: 'No, return to profile editor'
+        title: labels.cancelTitle,
+        question: labels.cancelQuestion,
+        confirm: labels.cancelConfirm,
+        dismiss: labels.cancelDismiss,
+        callback: function() {
+          window.location.href = `${window.location.origin}/my-profiles/`;
+        }
     });
 }
 

--- a/maps/templates/maps/profiles/cancel.html
+++ b/maps/templates/maps/profiles/cancel.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <p class="align-center">
-  <button id="invoke-dialog" type="button" class="button button--borderless"><span class="button__label">Cancel</span></button>
+  <button id="cancel-profile-creation" type="button" class="button button--borderless"><span class="button__label">{% trans 'Cancel' %}</span></button>
 </p>

--- a/maps/templates/maps/profiles/footer.html
+++ b/maps/templates/maps/profiles/footer.html
@@ -1,6 +1,9 @@
 {% load i18n %}
 {% load maps_extras %}
 <div class="spacer"></div>
+<script type="application/json" id="labels">
+{{ labels | to_json }}
+</script>
 <div class="align-center">
     <p>Page {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
     <p>

--- a/maps/views.py
+++ b/maps/views.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ImproperlyConfigured
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -29,6 +29,54 @@ from django_countries import countries
 from django.contrib.gis.geos import Point
 import os
 import requests
+
+
+class RedirectMixin:
+    redirect_url = None
+    redirect_message = None
+
+    def get_redirect_message(self):
+        redirect_message = self.redirect_message
+        if not redirect_message:
+            raise ImproperlyConfigured(
+                '{0} is missing the redirect_message attribute. Define {0}.redirect_message or override '
+                '{0}.get_redirect_message().'.format(self.__class__.__name__)
+            )
+        return str(redirect_message)
+
+    def get_redirect_url(self):
+        redirect_url = self.redirect_url
+        if not redirect_url:
+            raise ImproperlyConfigured(
+                '{0} is missing the redirect_url attribute. Define {0}.redirect_url or override '
+                '{0}.get_redirect_url().'.format(self.__class__.__name__)
+            )
+        return str(redirect_url)
+
+    def test_func(self):
+        raise NotImplementedError(
+            '{0} is missing the implementation of the test_func() method.'.format(self.__class__.__name__)
+        )
+
+    def get_test_func(self):
+        """
+        Override this method to use a different test_func method.
+        """
+        return self.test_func
+
+    def dispatch(self, request, *args, **kwargs):
+        test_result = self.get_test_func()()
+        if not test_result:
+            messages.error(self.request, self.get_redirect_message())
+            return redirect(self.get_redirect_url())
+        return super().dispatch(request, *args, **kwargs)
+
+
+class IndividualProfileRedirectMixin(RedirectMixin):
+    def test_func(self):
+        if self.request.user.has_profile:
+            return False
+        return True
 
 
 def contact_info_to_lng_lat(contact_info):
@@ -138,7 +186,10 @@ def show_scope_and_impact_condition(wizard):
     return False
 
 
-class IndividualProfileWizard(LoginRequiredMixin, SessionWizardView):
+class IndividualProfileWizard(LoginRequiredMixin, IndividualProfileRedirectMixin, SessionWizardView):
+    redirect_url = reverse_lazy('my-profiles')
+    redirect_message = _('You already have an individual profile.')
+
     def get_template_names(self):
         return [INDIVIDUAL_TEMPLATES[self.steps.current]]
 

--- a/maps/views.py
+++ b/maps/views.py
@@ -144,6 +144,14 @@ class IndividualProfileWizard(LoginRequiredMixin, SessionWizardView):
 
     def get_context_data(self, form, **kwargs):
         context = super().get_context_data(form=form, **kwargs)
+        context.update({
+            'labels': {
+                'cancelTitle': _('Cancel'),
+                'cancelQuestion': _('Are you sure you want to exit the profile editor and discard all of your information?'),
+                'cancelConfirm': _('Yes, exit and discard all info'),
+                'cancelDismiss': _('No, return to profile editor')
+            }
+        })
         context.update({'profile_type': 'individual'})
 
         if self.steps.current in ['more_about_you', 'detailed_info']:
@@ -350,6 +358,14 @@ class OrganizationProfileWizard(LoginRequiredMixin, SessionWizardView):
 
     def get_context_data(self, form, **kwargs):
         context = super().get_context_data(form=form, **kwargs)
+        context.update({
+            'labels': {
+                'cancelTitle': _('Cancel'),
+                'cancelQuestion': _('Are you sure you want to exit the profile editor and discard all of your information?'),
+                'cancelConfirm': _('Yes, exit and discard all info'),
+                'cancelDismiss': _('No, return to profile editor')
+            }
+        })
         context.update({'profile_type': 'organization'})
 
         if self.steps.current in ['basic_info', 'contact_info', 'detailed_info']:


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds functionality to the cancel button in individual and organizational profile flows, and blocks and redirects away from the individual profile creation flow if a user with a profile accesses it directly.

## Steps to test

1. Start individual and organizational profile creation.
2. Cancel part way through.
3. Create an individual profile.
4. After it's created, navigate directly to `/add/individual`.

**Expected behavior:** Cancellation terminates flow and redirects to `My Profiles`. Visiting `/add/individual` when you already have a profile redirects to `My Profiles` and displays an error message to that effect.

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here. -->
