### PR TITLE
feat: remove images from page headers

### DIFF
--- a/maps/static/maps/css/app.scss
+++ b/maps/static/maps/css/app.scss
@@ -460,8 +460,6 @@ h1 + .profile__meta {
 }
 
 .tabs [role="tabpanel"] {
-  @include full-width-background($off-white);
-
   --parent-background-color: var(--off-white);
 
   background-color: var(--off-white);
@@ -469,15 +467,17 @@ h1 + .profile__meta {
   padding-top: rem(54);
   position: relative;
 
+  @include full-width-background($off-white);
+
   @include breakpoint-up(md) {
     padding-bottom: rem(130);
   }
 }
 
 .profile .page-header {
-  @include full-width-background($white);
-
   background-color: var(--white);
+
+  @include full-width-background($white);
 }
 
 .profile main {
@@ -713,5 +713,47 @@ h1 + .profile__meta {
     .input-group + .input-group {
       margin-top: 0;
     }
+  }
+}
+
+.page.home {
+  [role="banner"] {
+    --parent-background-color: var(--blue-700);
+
+    background-color: var(--blue-700);
+    box-shadow: none;
+  }
+
+  .menu {
+    --parent-background-color: var(--blue-700);
+
+    background-color: var(--blue-700);
+  }
+
+  .banner-pattern {
+    display: none;
+  }
+
+  .page-header {
+    margin-top: 0;
+  }
+
+  .page-header::before {
+    background-color: var(--blue-700);
+  }
+
+  .home__search {
+    background-color: var(--blue-700);
+
+    &::before {
+      background-color: var(--blue-700);
+    }
+  }
+}
+
+.page.page--directory {
+  .page-header::before {
+    background-color: var(--blue-500);
+    background-image: unset;
   }
 }

--- a/maps/templates/maps/about.html
+++ b/maps/templates/maps/about.html
@@ -1,7 +1,7 @@
 {% extends 'maps/base.html' %}
 {% load maps_extras %}
 {% block title %}{{ title |titlify }}{% endblock %}
-{% block bodyclass %}page{% endblock %}
+{% block bodyclass %}page page--directory{% endblock %}
 {% block content %}
     <div class="page-header">
         <p><a class="link--breadcrumb" href="/">Home</a></p>

--- a/maps/templates/maps/privacy_policy.html
+++ b/maps/templates/maps/privacy_policy.html
@@ -2,12 +2,12 @@
 {% load i18n %}
 {% load maps_extras %}
 {% block title %}{{ title |titlify }}{% endblock %}
-{% block bodyclass %}page{% endblock %}
+{% block bodyclass %}page page--directory{% endblock %}
 {% block content %}
         <div class="page-header">
-        <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
-          <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
-        </div>
+        <p><a class="link--breadcrumb" href="/">{% trans 'Home' %}</a></p>
+        <h1>{% trans 'Privacy policy' %}</h1>
+    </div>
         <p>
             The Platform Cooperativism Consortium (PCC) is dedicated to respecting and protecting your privacy. At the
             PCC and ICDE, we are committed to making the processes and outcomes of our work transparent and accessible

--- a/maps/templates/maps/terms_of_service.html
+++ b/maps/templates/maps/terms_of_service.html
@@ -2,11 +2,11 @@
 {% load i18n %}
 {% load maps_extras %}
 {% block title %}{{ title |titlify }}{% endblock %}
-{% block bodyclass %}page{% endblock %}
+{% block bodyclass %}page page--directory{% endblock %}
 {% block content %}
     <div class="page-header">
-        <p><a class="link--breadcrumb" href="{% url 'index' %}">{% trans "Home" %}</a></p>
-        <h1><span class="pc-ff--sans pc-fw--normal">Platform Co-op</span><br/> Directory</h1>
+        <p><a class="link--breadcrumb" href="/">{% trans 'Home' %}</a></p>
+        <h1>{% trans 'Terms of service' %}</h1>
     </div>
     <h2>Terms of Use ("Terms")</h2>
 


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Removes resource library-style images from page headers.

## Steps to test

1. Visit Home, About, Terms of service.

**Expected behavior:** Page headers are displayed with simplified, solid-colour backgrounds.

## Additional information

Not applicable.

## Related issues

Not applicable.
