### PR TITLE
feat: add tool ID to tool API, add edited date to tool API

### DIFF
--- a/mdi/serializers.py
+++ b/mdi/serializers.py
@@ -78,6 +78,7 @@ class ToolSerializer(serializers.HyperlinkedModelSerializer):
         model = Tool
         fields = (
             'id',
+            'updated_at',
             'name',
             'description',
             'url',

--- a/mdi/serializers.py
+++ b/mdi/serializers.py
@@ -77,6 +77,7 @@ class ToolSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Tool
         fields = (
+            'id',
             'name',
             'description',
             'url',


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds tool ID to tools API endpoint so that edit links can be generated in the tool library; also adds a last modified date to the tools API endpoint.

## Steps to test

1. Visit `/api/tools/`.

**Expected behavior:** Each listed tool should have an ID and a last modified date.

## Additional information

Not applicable.

## Related issues

Not applicable.
