### PR TITLE
feat: add searching

### DIFF
--- a/maps/static/maps/css/app.scss
+++ b/maps/static/maps/css/app.scss
@@ -228,7 +228,8 @@ select[multiple] {
   }
 }
 
-.my-profiles .cards .card__wrapper {
+.my-profiles .cards .card__wrapper,
+.results .cards .card__wrapper {
   display: grid;
   gap: 1.25rem;
   grid-template-columns: 100%;
@@ -236,27 +237,31 @@ select[multiple] {
 }
 
 @media (min-width: 37.5rem) {
-  .my-profiles .cards {
+  .my-profiles .cards,
+  .results .cards {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
   }
 
   @supports (display:grid) {
-    .my-profiles .cards {
+    .my-profiles .cards,
+    .results .cards {
       display: grid;
       gap: 1.875rem;
       grid-template-columns: 100%;
     }
   }
 
-  .my-profiles .cards .card__wrapper {
+  .my-profiles .cards .card__wrapper,
+  .results .cards .card__wrapper {
     margin-bottom: 1.875rem;
     width: 100%;
   }
 
   @supports (display:grid) {
-    .my-profiles .cards .card__wrapper {
+    .my-profiles .cards .card__wrapper,
+    .results .cards .card__wrapper {
       margin-bottom: 0;
     }
   }
@@ -276,43 +281,51 @@ select[multiple] {
   }
 
   @supports (display:grid) {
-    .my-profiles .cards {
+    .my-profiles .cards,
+    .results .cards {
       grid-template-columns: repeat(2, 1fr);
     }
   }
 
-  .my-profiles .cards .card__wrapper {
+  .my-profiles .cards .card__wrapper,
+  .results .cards .card__wrapper {
     width: calc(50% - 0.9375rem);
   }
 
   @supports (display:grid) {
-    .my-profiles .cards .card__wrapper {
+    .my-profiles .cards .card__wrapper,
+    .results .cards .card__wrapper {
       width: 100%;
     }
   }
 
-  .my-profiles .card:nth-child(2n) {
+  .my-profiles .card:nth-child(2n),
+  .results .card:nth-child(2n) {
     margin-left: 1.875rem;
   }
 
   @supports (display:grid) {
-    .my-profiles .card:nth-child(2n) {
+    .my-profiles .card:nth-child(2n),
+    .results .card:nth-child(2n) {
       margin-left: 0;
     }
   }
 
-  .my-profiles .cards .card__wrapper + .card__wrapper {
+  .my-profiles .cards .card__wrapper + .card__wrapper,
+  .results .cards .card__wrapper + .card__wrapper {
     margin-top: 0;
   }
 }
 
 @media (min-width: 80rem) {
-  .my-profiles main {
+  .my-profiles main,
+  .results main {
     width: calc(66.66667% - 0.625rem);
   }
 
   @supports (display:grid) {
-    .my-profiles main {
+    .my-profiles main,
+    .results main {
       grid-column: 3/11;
       width: 100%;
     }
@@ -320,12 +333,14 @@ select[multiple] {
 }
 
 @media (min-width: 120rem) {
-  .my-profiles main {
+  .my-profiles main,
+  .results main {
     width: calc(50% - 0.9375rem);
   }
 
   @supports (display:grid) {
-    .my-profiles main {
+    .my-profiles main,
+    .results main {
       grid-column: 4/12;
       width: 100%;
     }

--- a/maps/templates/maps/header.html
+++ b/maps/templates/maps/header.html
@@ -14,15 +14,7 @@
           {% icon 'search' %}
         </button>
 
-        <form role="search" method="get" class="search-form search-form--inverse" action="#">
-          <label>
-            <span class="screen-reader-text">{% trans 'search' %}</span>
-            <input id="s" name="s" type="search" />
-          </label>
-          <button type="submit" class="button button--search"><span class="screen-reader-text">{% trans 'submit search' %}</span>
-            {% icon 'search' %}
-          </button>
-        </form>
+        {% include 'maps/search.html' %}
       {% endif %}
 
         <nav class="nav" aria-labelledby="menu-primary-label">

--- a/maps/templates/maps/search--home.html
+++ b/maps/templates/maps/search--home.html
@@ -1,11 +1,13 @@
 {% load maps_extras %}
+{% load i18n %}
 <section class="home__search">
-<form role="search" method="get" class="search-form search-form--inverse" action="/">
+<form role="search" method="get" class="search-form search-form--inverse" action="{% url 'search_results' %}">
+    <!-- {% csrf_token %} -->
     <label>
-        <span class="screen-reader-text">search</span>
-        <input id="s" name="s" placeholder="Search by co-op or individual name, details, or tags…" type="search">
+        <span class="screen-reader-text">{% trans 'search' %}</span>
+        <input id="s" name="s" placeholder="{% trans 'Search by co-op or individual name, details, or tags…' %}" type="search">
     </label>
-    <button type="submit" class="button button--search" disabled><span class="screen-reader-text">submit search</span> {% icon 'search' %}
+    <button type="submit" class="button button--search"><span class="screen-reader-text">{% trans 'submit search' %}</span> {% icon 'search' %}
 </button>
 </form>
 </section>

--- a/maps/templates/maps/search.html
+++ b/maps/templates/maps/search.html
@@ -1,8 +1,10 @@
 {% load maps_extras %}
-<form role="search" method="get" class="search-form" action="/">
+{% load i18n %}
+<form role="search" method="get" class="search-form" action="{% url 'search_results' %}">
+    <!-- {% csrf_token %} -->
     <label>
-        <span class="screen-reader-text">search</span>
-        <input id="s" name="s" placeholder="Search by co-op or individual name, details, or tags…" type="search">
+        <span class="screen-reader-text">{% trans 'search' %}</span>
+        <input id="s" name="s" placeholder="{% trans 'Search…' %}" type="search">
     </label>
-    <button type="submit" class="button button--search"><span class="screen-reader-text">submit search</span> {% icon 'search' %}</button>
+    <button type="submit" class="button button--search"><span class="screen-reader-text">{% trans 'submit search' %}</span> {% icon 'search' %}</button>
 </form>

--- a/maps/templates/maps/search_results.html
+++ b/maps/templates/maps/search_results.html
@@ -1,0 +1,34 @@
+{% extends 'maps/base.html' %}
+{% load i18n %}
+{% load maps_extras %}
+{% block title %}{{ 'Search results' |titlify }}{% endblock %}
+{% block bodyclass %}results{% endblock %}
+{% block content %}
+    <div class="page-header">
+        <p><a class="link--breadcrumb" href="/">{% trans 'Home' %}</a></p>
+        <h1>{% blocktrans with search_term=search_term %}Search results for “{{ search_term }}”{% endblocktrans %}</h1>
+    </div>
+    {% include 'maps/partials/messages.html' %}
+    {% if object_list %}
+    <h2 aria-role="status">{% if object_list|length > 1 %}{% blocktrans with org_count=object_list|length %}{{org_count}} organizations found{% endblocktrans %}{% else %}{% trans '1 organization found' %}{% endif %}</h2>
+    <ul class="cards">
+        {% for organization in object_list %}
+        {% include 'maps/partials/card_organization.html' %}
+        {% endfor %}
+    </ul>
+    {% else %}
+    <h2 aria-role="status">{% trans 'No organizations found' %}</h2>
+    <p>{% trans 'No organizations matched your search term.' %}</p>
+    {% endif %}
+    {% if individual_list %}
+    <h2 aria-role="status">{% if individual_list|length > 1 %}{% blocktrans with individual_count=individual_list|length %}{{individual_count}} individuals found{% endblocktrans %}{% else %}{% trans '1 individual found' %}{% endif %}</h2>
+    <ul class="cards">
+        {% for individual in individual_list %}
+        {% include 'maps/partials/card_individual.html' %}
+        {% endfor %}
+    </ul>
+    {% else %}
+    <h2 aria-role="status">{% trans 'No individuals found' %}</h2>
+    <p>{% trans 'No individuals matched your search term.' %}</p>
+    {% endif %}
+{% endblock %}

--- a/maps/urls.py
+++ b/maps/urls.py
@@ -4,7 +4,7 @@ from . import views
 from .views import INDIVIDUAL_FORMS, ORGANIZATION_FORMS, TOOL_FORMS, show_more_about_you_condition, show_scope_and_impact_condition,\
     IndividualProfileWizard, OrganizationProfileWizard, ToolWizard, OrganizationDelete, PrivacyPolicyView, TermsOfServiceView, AboutPageView,\
     InvididualOverviewUpdate, InvididualBasicInfoUpdate, OrganizationBasicInfoUpdate, OrganizationOverviewUpdate, OrganizationContactUpdate,\
-    SummaryPageView, ToolUpdate
+    SummaryPageView, ToolUpdate, SearchResultsView
 from accounts.models import UserSocialNetwork
 from mdi.models import SocialNetwork
 
@@ -26,6 +26,7 @@ urlpatterns = [
     path('accounts/', views.account_settings, name='account-settings'),
     path('about/', AboutPageView.as_view(), {'title': 'About'}, name='about'),
     path('about/impact/', SummaryPageView.as_view(), {'title': 'Summary of Impact'}, name='impact'),
+    path('search/', SearchResultsView.as_view(), name='search_results'),
     path('privacy-policy/', PrivacyPolicyView.as_view(), {'title': 'Privacy Policy'}, name='privacy_policy'),
     path('terms-of-service/', TermsOfServiceView.as_view(), {'title': 'Terms of Service'}, name='terms_of_service'),
 ]


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds search.

## Steps to test

1. Use search field on home page or inner pages (in navigation).

**Expected behavior:** Search results display in a grid of cards grouped by organizations and individuals.

## Additional information

This implementation does not support searching on the map, but provides some location-based searching (e.g. a search for "Iowa" returns organizations with Iowa in the state field or description, and a search for "NZ" returns organizations with New Zealand as the country).

## Related issues

Resolves #36.
