### PR TITLE
feat: disable lockdown (resolves #140)

### DIFF
--- a/cmdi/settings.py
+++ b/cmdi/settings.py
@@ -101,7 +101,7 @@ CORS_ORIGIN_ALLOW_ALL = True
 # django-lockdown is being used to deter the curious during development.
 # Keep it after launch should site access ever need to be disabled due to some emergency.
 LOCKDOWN_PASSWORDS = ('six', '6',)
-LOCKDOWN_ENABLED = True  # Default is True. A quick way to make the site inaccessible.
+LOCKDOWN_ENABLED = False  # Default is True. A quick way to make the site inaccessible.
 LOCKDOWN_URL_EXCEPTIONS = (
     r'^/swagger.json$',
     r'^/api/organizations/.*$',


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Simply sets `LOCKDOWN_ENABLED` to `False`.

## Steps to test

1. Log out.
2. Visit home page.

**Expected behavior:** No more lockdown.

## Additional information

Not applicable.

## Related issues

Resolves #140.
